### PR TITLE
Update status and metadata to CG-DRAFT and fix broken links

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1,17 +1,15 @@
 <pre class="metadata">
 Shortname: webxr-body-tracking
 Title: WebXR Body Tracking Module - Level 1
-Group: immersivewebwg
-Status: UD
-TR: https://www.w3.org/TR/webxr-body-tracking-1/
+Group: immersivewebcg
+Status: CG-DRAFT
 ED: https://immersive-web.github.io/webxr-body-tracking/
-Previous Version: https://www.w3.org/TR/2020/WD-webxr-body-tracking-1-20210824/
-Repository: immersive-web/webxr-body-tracking
+Repository: immersive-web/body-tracking
 Level: 1
 Mailing List Archives: https://lists.w3.org/Archives/Public/public-immersive-web-wg/
 
-!Participate: <a href="https://github.com/immersive-web/webxr-body-tracking/issues/new">File an issue</a> (<a href="https://github.com/immersive-web/webxr-body-tracking/issues">open issues</a>)
-!Participate: <a href="https://lists.w3.org/Archives/Public/public-immersive-web-wg/">Mailing list archive</a>
+!Participate: <a href="https://github.com/immersive-web/body-tracking/issues/new">File an issue</a> (<a href="https://github.com/immersive-web/body-tracking/issues">open issues</a>)
+!Participate: <a href="https://lists.w3.org/Archives/Public/public-immersive-web/">Mailing list archive</a>
 !Participate: <a href="irc://irc.w3.org:6665/">W3C's #immersive-web IRC</a>
 
 Editor: Rik Cabanier, Meta, cabanier@meta.com

--- a/index.bs
+++ b/index.bs
@@ -3,7 +3,7 @@ Shortname: webxr-body-tracking
 Title: WebXR Body Tracking Module - Level 1
 Group: immersivewebcg
 Status: CG-DRAFT
-ED: https://immersive-web.github.io/webxr-body-tracking/
+ED: https://immersive-web.github.io/body-tracking/
 Repository: immersive-web/body-tracking
 Level: 1
 Mailing List Archives: https://lists.w3.org/Archives/Public/public-immersive-web-wg/


### PR DESCRIPTION
The status of the spec was "Unofficial Proposal Draft" and the metadata associated the spec with the Immersive Web WG, while my understanding is that the spec is under incubation in the CG (with a plan to adopt it in the WG after incubation).

This update associates the spec with the CG, bumps the status to CG-DRAFT, and fixes a few broken links.